### PR TITLE
QEMU agents to retrieve IPS is working

### DIFF
--- a/terraform/clusters/proxmox/env/homelab/terraform.tfvars
+++ b/terraform/clusters/proxmox/env/homelab/terraform.tfvars
@@ -4,3 +4,4 @@ worker            = 2
 target_node       = "proxmox"
 storage           = "samsung-ssd"
 full_clone        = true
+template_name     = "cluster-testing"

--- a/terraform/clusters/proxmox/locals.tf
+++ b/terraform/clusters/proxmox/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  controller_ips = { for i, vm in proxmox_vm_qemu.controller : "controller${i + 1}" => vm.default_ipv4_address }
+  worker_ips = { for i, vm in proxmox_vm_qemu.controller : "worker${i + 1}" => vm.default_ipv4_address }
+}

--- a/terraform/clusters/proxmox/main.tf
+++ b/terraform/clusters/proxmox/main.tf
@@ -6,9 +6,11 @@ resource "proxmox_vm_qemu" "controller" {
     cores       = 2
     scsihw      = "virtio-scsi-single"
     full_clone  = var.full_clone
+    agent       = 1
+    #ipconfig0   = "dhcp"
 
     ### or for a Clone VM operation
-    clone = "cluster-template"
+    clone = var.template_name
     disks {
         scsi {
             scsi0 {
@@ -44,9 +46,12 @@ resource "proxmox_vm_qemu" "worker" {
     memory      = 4096
     cores       = 2
     scsihw      = "virtio-scsi-single"
+    full_clone  = var.full_clone
+    agent       = 1
+    #ipconfig0   = "dhcp"
 
     ### or for a Clone VM operation
-    clone = "cluster-template"
+    clone = var.template_name
     disks {
         scsi {
             scsi0 {

--- a/terraform/clusters/proxmox/outputs.tf
+++ b/terraform/clusters/proxmox/outputs.tf
@@ -1,7 +1,7 @@
 output "controllers_ips" {
-  value = [for i, vm in proxmox_vm_qemu.controller : "controller${i + 1} ${vm.default_ipv4_address}" ]
+  value = local.controller_ips
 }
 
 output "workers_ips" {
-  value = [for i, vm in proxmox_vm_qemu.worker : "worker${i + 1} ${vm.default_ipv4_address}" ]
+  value = local.worker_ips
 }

--- a/terraform/clusters/proxmox/outputs.tf
+++ b/terraform/clusters/proxmox/outputs.tf
@@ -1,0 +1,7 @@
+output "controllers_ips" {
+  value = [for i, vm in proxmox_vm_qemu.controller : "controller${i + 1} ${vm.default_ipv4_address}" ]
+}
+
+output "workers_ips" {
+  value = [for i, vm in proxmox_vm_qemu.worker : "worker${i + 1} ${vm.default_ipv4_address}" ]
+}

--- a/terraform/clusters/proxmox/variables.tf
+++ b/terraform/clusters/proxmox/variables.tf
@@ -44,3 +44,9 @@ variable "full_clone" {
   type        = bool
   default     = false
 }
+
+variable "template_name" {
+  description = "If you required full clone or not"
+  type        = string
+  default     = "cluster-template"
+}


### PR DESCRIPTION
- Prerequisite is having the qemu agent installed in the nodes, I have an alma template that contains the necessary underlying software to speed up the process of running VMs. I'll use a different repository to maintain the hardening of the golden image.